### PR TITLE
Allow service and method names to be overridden when building a ServiceDescriptor

### DIFF
--- a/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureServer.java
+++ b/examples/grpc/security/src/main/java/io/helidon/grpc/examples/security/SecureServer.java
@@ -56,14 +56,20 @@ public class SecureServer {
                 .addProvider(HttpBasicAuthProvider.create(config.get("http-basic-auth")))
                 .build();
 
-        ServiceDescriptor greetService = ServiceDescriptor.builder(new GreetService(config))
+        ServiceDescriptor greetService1 = ServiceDescriptor.builder(new GreetService(config))
+                .name("GreetService")
                 .intercept(GrpcSecurity.rolesAllowed("user"))
                 .intercept("SetGreeting", GrpcSecurity.rolesAllowed("admin"))
                 .build();
 
+        ServiceDescriptor greetService2 = ServiceDescriptor.builder(new GreetService(config))
+                .name("GreetService2")
+                .build();
+
         GrpcRouting grpcRouting = GrpcRouting.builder()
                 .intercept(GrpcSecurity.create(security).securityDefaults(GrpcSecurity.authenticate()))
-                .register(greetService)
+                .register(greetService1)
+                .register(greetService2)
                 .register(new StringService())
                 .build();
 

--- a/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHelper.java
+++ b/grpc/core/src/main/java/io/helidon/grpc/core/GrpcHelper.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.grpc.core;
+
+/**
+ * Helper methods for common gRPC tasks.
+ *
+ * @author Jonathan Knight
+ */
+public final class GrpcHelper {
+
+    /**
+     * Private constructor for utility class.
+     */
+    private GrpcHelper() {
+    }
+
+    /**
+     * Extract the gRPC service name from a method full name.
+     *
+     * @param fullMethodName  the gRPC method full name
+     *
+     * @return  the service name extracted from the full name
+     */
+    public static String extractServiceName(String fullMethodName) {
+        int index = fullMethodName.indexOf('/');
+        return index == -1 ? fullMethodName : fullMethodName.substring(0, index);
+    }
+
+    /**
+     * Extract the name prefix from from a method full name.
+     * <p>
+     * The prefix is everything upto the but not including the last
+     * '/' character in the full name.
+     *
+     * @param fullMethodName  the gRPC method full name
+     *
+     * @return  the name prefix extracted from the full name
+     */
+    public static String extractNamePrefix(String fullMethodName) {
+        int index = fullMethodName.lastIndexOf('/');
+        return index == -1 ? fullMethodName : fullMethodName.substring(0, index);
+    }
+
+    /**
+     * Extract the gRPC method name from a method full name.
+     *
+     * @param fullMethodName  the gRPC method full name
+     *
+     * @return  the method name extracted from the full name
+     */
+    public static String extractMethodName(String fullMethodName) {
+        int index = fullMethodName.lastIndexOf('/');
+        return index == -1 ? fullMethodName : fullMethodName.substring(index + 1);
+    }
+}

--- a/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHelperTest.java
+++ b/grpc/core/src/test/java/io/helidon/grpc/core/GrpcHelperTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2019 Oracle and/or its affiliates. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.grpc.core;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * @author Jonathan Knight
+ */
+public class GrpcHelperTest {
+
+    @Test
+    public void shouldExtractServiceName() {
+        String fullName = "Foo/1234/Bar";
+
+        assertThat(GrpcHelper.extractServiceName(fullName), is("Foo"));
+    }
+
+    @Test
+    public void shouldExtractMethodName() {
+        String fullName = "Foo/1234/Bar";
+
+        assertThat(GrpcHelper.extractMethodName(fullName), is("Bar"));
+    }
+
+    @Test
+    public void shouldExtractNamePrefix() {
+        String fullName = "Foo/1234/Bar";
+
+        assertThat(GrpcHelper.extractNamePrefix(fullName), is("Foo/1234"));
+    }
+}

--- a/grpc/server/src/main/java/io/helidon/grpc/server/ContextSettingServerInterceptor.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/ContextSettingServerInterceptor.java
@@ -27,6 +27,8 @@ import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 
+import static io.helidon.grpc.core.GrpcHelper.extractMethodName;
+
 /**
  * A {@link io.grpc.ServerInterceptor} that sets values into the
  * gRPC call context.
@@ -49,7 +51,7 @@ class ContextSettingServerInterceptor
 
         Context context = Context.current();
         String fullMethodName = call.getMethodDescriptor().getFullMethodName();
-        String methodName = ServiceDescriptor.Builder.extractMethodName(fullMethodName);
+        String methodName = extractMethodName(fullMethodName);
         MethodDescriptor methodDescriptor = serviceDescriptor.method(methodName);
         Map<Context.Key<?>, Object> contextMap = new HashMap<>();
 

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcMetrics.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcMetrics.java
@@ -34,6 +34,8 @@ import org.eclipse.microprofile.metrics.MetricRegistry;
 import org.eclipse.microprofile.metrics.MetricType;
 import org.eclipse.microprofile.metrics.Timer;
 
+import static io.helidon.grpc.core.GrpcHelper.extractMethodName;
+
 /**
  * A {@link io.grpc.ServerInterceptor} that enables capturing of gRPC call metrics.
  */
@@ -122,7 +124,7 @@ public class GrpcMetrics
                                                                  ServerCallHandler<ReqT, RespT> next) {
 
         String fullMethodName = call.getMethodDescriptor().getFullMethodName();
-        String methodName = ServiceDescriptor.Builder.extractMethodName(fullMethodName);
+        String methodName = extractMethodName(fullMethodName);
         String metricName = fullMethodName.replace('/', '.');
 
         ServerCall<ReqT, RespT> serverCall;

--- a/grpc/server/src/test/java/io/helidon/grpc/server/MethodDescriptorTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/MethodDescriptorTest.java
@@ -54,9 +54,11 @@ public class MethodDescriptorTest {
         assertThat(descriptor.name(), is("foo"));
         assertThat(descriptor.metricType(), is(nullValue()));
         assertThat(descriptor.callHandler(), is(sameInstance(handler)));
-        assertThat(descriptor.descriptor(), is(sameInstance(grpcDescriptor)));
         assertThat(descriptor.context(), is(notNullValue()));
         assertThat(descriptor.context().size(), is(0));
+
+        io.grpc.MethodDescriptor methodDescriptor = descriptor.descriptor();
+        assertThat(methodDescriptor.getFullMethodName(), is("EchoService/foo"));
     }
 
     @Test
@@ -77,7 +79,6 @@ public class MethodDescriptorTest {
         assertThat(descriptor.name(), is("foo"));
         assertThat(descriptor.metricType(), is(MetricType.COUNTER));
         assertThat(descriptor.callHandler(), is(sameInstance(handler)));
-        assertThat(descriptor.descriptor(), is(sameInstance(grpcDescriptor)));
         assertThat(descriptor.context(), is(notNullValue()));
         assertThat(descriptor.context().size(), is(0));
     }
@@ -100,7 +101,6 @@ public class MethodDescriptorTest {
         assertThat(descriptor.name(), is("foo"));
         assertThat(descriptor.metricType(), is(MetricType.HISTOGRAM));
         assertThat(descriptor.callHandler(), is(sameInstance(handler)));
-        assertThat(descriptor.descriptor(), is(sameInstance(grpcDescriptor)));
         assertThat(descriptor.context(), is(notNullValue()));
         assertThat(descriptor.context().size(), is(0));
     }
@@ -123,7 +123,6 @@ public class MethodDescriptorTest {
         assertThat(descriptor.name(), is("foo"));
         assertThat(descriptor.metricType(), is(MetricType.METERED));
         assertThat(descriptor.callHandler(), is(sameInstance(handler)));
-        assertThat(descriptor.descriptor(), is(sameInstance(grpcDescriptor)));
         assertThat(descriptor.context(), is(notNullValue()));
         assertThat(descriptor.context().size(), is(0));
     }
@@ -146,7 +145,6 @@ public class MethodDescriptorTest {
         assertThat(descriptor.name(), is("foo"));
         assertThat(descriptor.metricType(), is(MetricType.TIMER));
         assertThat(descriptor.callHandler(), is(sameInstance(handler)));
-        assertThat(descriptor.descriptor(), is(sameInstance(grpcDescriptor)));
         assertThat(descriptor.context(), is(notNullValue()));
         assertThat(descriptor.context().size(), is(0));
     }
@@ -169,7 +167,6 @@ public class MethodDescriptorTest {
         assertThat(descriptor.name(), is("foo"));
         assertThat(descriptor.metricType(), is(MetricType.INVALID));
         assertThat(descriptor.callHandler(), is(sameInstance(handler)));
-        assertThat(descriptor.descriptor(), is(sameInstance(grpcDescriptor)));
         assertThat(descriptor.context(), is(notNullValue()));
         assertThat(descriptor.context().size(), is(0));
     }
@@ -193,7 +190,6 @@ public class MethodDescriptorTest {
         assertThat(descriptor.name(), is("foo"));
         assertThat(descriptor.metricType(), is(nullValue()));
         assertThat(descriptor.callHandler(), is(sameInstance(handler)));
-        assertThat(descriptor.descriptor(), is(sameInstance(grpcDescriptor)));
         assertThat(descriptor.context(), is(notNullValue()));
         assertThat(descriptor.context().size(), is(1));
         assertThat(descriptor.context().get(key), is("test-value"));
@@ -253,5 +249,25 @@ public class MethodDescriptorTest {
                 .build();
 
         assertThat(descriptor.interceptors(), contains(interceptor1, interceptor2, interceptor3));
+    }
+
+    @Test
+    public void shouldSetName() {
+        ServerCallHandler handler = mock(ServerCallHandler.class);
+        io.grpc.MethodDescriptor grpcDescriptor = EchoServiceGrpc.getServiceDescriptor()
+                .getMethods()
+                .stream()
+                .filter(md -> md.getFullMethodName().equals("EchoService/Echo"))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Could not find echo method"));
+
+        Context.Key<String> key = Context.key("test");
+        MethodDescriptor descriptor = MethodDescriptor.builder("foo", grpcDescriptor, handler)
+                .fullname("Test/bar")
+                .build();
+
+        assertThat(descriptor, is(notNullValue()));
+        assertThat(descriptor.name(), is("foo"));
+        assertThat(descriptor.descriptor().getFullMethodName(), is("Test/bar"));
     }
 }


### PR DESCRIPTION
Allow service and method names to be overridden when building a ServiceDescriptor