### PR TITLE
Rename gRPC server `ServiceDescriptor.Config` and `MethodDescriptor.Config` interfaces

### DIFF
--- a/docs/src/main/docs/grpc/01_introduction.adoc
+++ b/docs/src/main/docs/grpc/01_introduction.adoc
@@ -44,8 +44,8 @@ Here is the code for a minimalist gRPC application that runs on a default port (
 
     static class HelloService implements GrpcService { <5>
         @Override
-        public void update(ServiceDescriptor.Config config) {
-            config.unary("SayHello", ((request, responseObserver) -> complete(responseObserver, "Hello World!"))); // <6>
+        public void update(ServiceDescriptor.Rules rules) {
+            rules.unary("SayHello", ((request, responseObserver) -> complete(responseObserver, "Hello World!"))); // <6>
         }
     }
 ----

--- a/docs/src/main/docs/grpc/04_service_implementation.adoc
+++ b/docs/src/main/docs/grpc/04_service_implementation.adoc
@@ -55,8 +55,8 @@ interface and define one or more methods for the service:
 class EchoService implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.unary("Echo", this::echo); // <1>
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.unary("Echo", this::echo); // <1>
     }
 
     /**
@@ -135,10 +135,9 @@ The service implementation will be very similar to our original implementation:
 class EchoService implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config
-            .proto(Echo.getDescriptor())  // <1>
-            .unary("Echo", this::echo);   // <2>
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.proto(Echo.getDescriptor())  // <1>
+             .unary("Echo", this::echo);   // <2>
     }
 
     /**

--- a/docs/src/main/docs/grpc/05_interceptors.adoc
+++ b/docs/src/main/docs/grpc/05_interceptors.adoc
@@ -73,8 +73,8 @@ You can also register an interceptor for a specific service, either by implement
 public class MyService implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.intercept(new LoggingInterceptor())   // <1>
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.intercept(new LoggingInterceptor())   // <1>
                 .unary("MyMethod", this::myMethod);
     }
 
@@ -108,8 +108,8 @@ Finally, you can also register an interceptor at the method level:
 public class MyService implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.unary("MyMethod",
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.unary("MyMethod",
                      this::myMethod,
                      cfg -> cfg.intercept(new LoggingInterceptor()));  // <1>
     }

--- a/docs/src/main/docs/grpc/06_health_checks.adoc
+++ b/docs/src/main/docs/grpc/06_health_checks.adoc
@@ -40,8 +40,8 @@ directly within `GrpcService` implementation:
 public class MyService implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.unary("MyMethod", this::myMethod)
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.unary("MyMethod", this::myMethod)
                 .healthCheck(this::healthCheck);  // <1>
     }
 

--- a/docs/src/main/docs/grpc/07_metrics.adoc
+++ b/docs/src/main/docs/grpc/07_metrics.adoc
@@ -75,8 +75,8 @@ either service or the method level:
     public static class MyService implements GrpcService {
 
         @Override
-        public void update(ServiceDescriptor.Config config) {
-            config
+        public void update(ServiceDescriptor.Rules rules) {
+            rules
                 .metered()                                              // <2>
                 .unary("MyMethod", this::myMethod, cfg -> cfg.timed())  // <3>
         }

--- a/examples/grpc/common/src/main/java/io/helidon/grpc/examples/common/GreetService.java
+++ b/examples/grpc/common/src/main/java/io/helidon/grpc/examples/common/GreetService.java
@@ -48,8 +48,8 @@ public class GreetService implements GrpcService {
     }
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.proto(Greet.getDescriptor())
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.proto(Greet.getDescriptor())
                 .unary("Greet", this::greet)
                 .unary("SetGreeting", this::setGreeting)
                 .healthCheck(this::healthCheck);

--- a/examples/grpc/common/src/main/java/io/helidon/grpc/examples/common/GreetServiceJava.java
+++ b/examples/grpc/common/src/main/java/io/helidon/grpc/examples/common/GreetServiceJava.java
@@ -44,10 +44,9 @@ public class GreetServiceJava
     }
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config
-                .unary("Greet", this::greet)
-                .unary("SetGreeting", this::setGreeting);
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.unary("Greet", this::greet)
+             .unary("SetGreeting", this::setGreeting);
     }
 
     // ---- service methods -------------------------------------------------

--- a/examples/grpc/common/src/main/java/io/helidon/grpc/examples/common/StringService.java
+++ b/examples/grpc/common/src/main/java/io/helidon/grpc/examples/common/StringService.java
@@ -32,8 +32,8 @@ import io.grpc.stub.StreamObserver;
 public class StringService
         implements GrpcService {
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.proto(Strings.getDescriptor())
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.proto(Strings.getDescriptor())
                 .unary("Upper", this::upper)
                 .unary("Lower", this::lower)
                 .serverStreaming("Split", this::split)

--- a/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureServer.java
+++ b/examples/grpc/security-outbound/src/main/java/io/helidon/grpc/examples/security/outbound/SecureServer.java
@@ -166,8 +166,8 @@ public class SecureServer {
         }
 
         @Override
-        public void update(ServiceDescriptor.Config config) {
-            config.proto(Greet.getDescriptor())
+        public void update(ServiceDescriptor.Rules rules) {
+            rules.proto(Greet.getDescriptor())
                     .unary("Greet", this::greet)
                     .unary("SetGreeting", this::setGreeting);
         }

--- a/grpc/client/src/test/java/services/EchoService.java
+++ b/grpc/client/src/test/java/services/EchoService.java
@@ -29,8 +29,8 @@ public class EchoService
         implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.proto(Echo.getDescriptor())
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.proto(Echo.getDescriptor())
                 .unary("Echo", this::echo);
     }
 

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcRouting.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcRouting.java
@@ -127,7 +127,7 @@ public interface GrpcRouting {
          *                   for the registered service
          * @return this builder to allow fluent method chaining
          */
-        public Builder register(GrpcService service, Consumer<ServiceDescriptor.Config> configurer) {
+        public Builder register(GrpcService service, Consumer<ServiceDescriptor.Rules> configurer) {
             return register(ServiceDescriptor.builder(service), configurer);
         }
 
@@ -149,7 +149,7 @@ public interface GrpcRouting {
          *                   for the registered service
          * @return this builder to allow fluent method chaining
          */
-        public Builder register(BindableService service, Consumer<ServiceDescriptor.Config> configurer) {
+        public Builder register(BindableService service, Consumer<ServiceDescriptor.Rules> configurer) {
             return register(ServiceDescriptor.builder(service), configurer);
         }
 
@@ -177,7 +177,7 @@ public interface GrpcRouting {
 
         @SuppressWarnings("unchecked")
         private Builder register(ServiceDescriptor.Builder builder,
-                                 Consumer<ServiceDescriptor.Config> configurer) {
+                                 Consumer<ServiceDescriptor.Rules> configurer) {
             if (configurer != null) {
                 configurer.accept(builder);
             }
@@ -194,7 +194,7 @@ public interface GrpcRouting {
         private boolean isServiceDescriptorConfigConsumer(ServerInterceptor interceptor) {
             if (interceptor instanceof Consumer) {
                 try {
-                    interceptor.getClass().getMethod("accept", ServiceDescriptor.Config.class);
+                    interceptor.getClass().getMethod("accept", ServiceDescriptor.Rules.class);
                     return true;
                 } catch (NoSuchMethodException e) {
                     return false;

--- a/grpc/server/src/main/java/io/helidon/grpc/server/GrpcService.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/GrpcService.java
@@ -41,9 +41,9 @@ public interface GrpcService {
     /**
      * Update service configuration.
      *
-     * @param config configuration to update
+     * @param rules configuration to update
      */
-    void update(ServiceDescriptor.Config config);
+    void update(ServiceDescriptor.Rules rules);
 
     /**
      * Obtain the name of this service.

--- a/grpc/server/src/main/java/io/helidon/grpc/server/MethodDescriptor.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/MethodDescriptor.java
@@ -128,41 +128,41 @@ public class MethodDescriptor<ReqT, ResT> {
      * @param <ReqT> request type
      * @param <ResT> response type
      */
-    public interface Config<ReqT, ResT> {
+    public interface Rules<ReqT, ResT> {
         /**
          * Collect metrics for this method using {@link org.eclipse.microprofile.metrics.Counter}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link MethodDescriptor.Rules} instance for fluent call chaining
          */
-        Config<ReqT, ResT> counted();
+        Rules<ReqT, ResT> counted();
 
         /**
          * Collect metrics for this method using {@link org.eclipse.microprofile.metrics.Meter}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link MethodDescriptor.Rules} instance for fluent call chaining
          */
-        Config<ReqT, ResT> metered();
+        Rules<ReqT, ResT> metered();
 
         /**
          * Collect metrics for this method using {@link org.eclipse.microprofile.metrics.Histogram}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link MethodDescriptor.Rules} instance for fluent call chaining
          */
-        Config<ReqT, ResT> histogram();
+        Rules<ReqT, ResT> histogram();
 
         /**
          * Collect metrics for this method using {@link org.eclipse.microprofile.metrics.Timer}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link MethodDescriptor.Rules} instance for fluent call chaining
          */
-        Config<ReqT, ResT> timed();
+        Rules<ReqT, ResT> timed();
 
         /**
          * Explicitly disable metrics collection for this service.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link MethodDescriptor.Rules} instance for fluent call chaining
          */
-        Config<ReqT, ResT> disableMetrics();
+        Rules<ReqT, ResT> disableMetrics();
 
         /**
          * Add a {@link Context.Key} and value to be added to the call {@link io.grpc.Context}
@@ -172,21 +172,21 @@ public class MethodDescriptor<ReqT, ResT> {
          * @param value  the value to map to the {@link Context.Key}
          * @param <T>    the type of the {@link Context.Key} and value
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link MethodDescriptor.Rules} instance for fluent call chaining
          *
          * @throws java.lang.NullPointerException if the key parameter is null
          */
 
-        <T> Config<ReqT, ResT>  addContextKey(Context.Key<T> key, T value);
+        <T> Rules<ReqT, ResT> addContextKey(Context.Key<T> key, T value);
 
         /**
          * Register one or more {@link io.grpc.ServerInterceptor interceptors} for the method.
          *
          * @param interceptors the interceptor(s) to register
          *
-         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Config} instance for fluent call chaining
+         * @return this {@link ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config<ReqT, ResT> intercept(ServerInterceptor... interceptors);
+        Rules<ReqT, ResT> intercept(ServerInterceptor... interceptors);
     }
 
     /**
@@ -195,7 +195,7 @@ public class MethodDescriptor<ReqT, ResT> {
      * @param <ReqT> request type
      * @param <ResT> response type
      */
-    static final class Builder<ReqT, ResT> implements Config<ReqT, ResT>, io.helidon.common.Builder<MethodDescriptor<ReqT, ResT>> {
+    static final class Builder<ReqT, ResT> implements Rules<ReqT, ResT>, io.helidon.common.Builder<MethodDescriptor<ReqT, ResT>> {
         private final String name;
         private final io.grpc.MethodDescriptor.Builder<ReqT, ResT> descriptor;
         private final ServerCallHandler<ReqT, ResT> callHandler;

--- a/grpc/server/src/main/java/io/helidon/grpc/server/ServiceDescriptor.java
+++ b/grpc/server/src/main/java/io/helidon/grpc/server/ServiceDescriptor.java
@@ -160,18 +160,18 @@ public class ServiceDescriptor {
     // ---- inner interface: Config -----------------------------------------
 
     /**
-     * Fluent configuration interface for the {@link io.helidon.grpc.server.ServiceDescriptor}.
+     * Fluent configuration interface for the {@link ServiceDescriptor}.
      */
-    public interface Config {
+    public interface Rules {
         /**
          * Set the name for the service.
          *
          * @param name the service name
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          * @throws java.lang.NullPointerException if the name is null
          * @throws java.lang.IllegalArgumentException if the name is a blank String
          */
-        Config name(String name);
+        Rules name(String name);
 
         /**
          * Obtain the name fo the service this configuration configures.
@@ -183,25 +183,25 @@ public class ServiceDescriptor {
          * Register the proto for the service.
          *
          * @param proto the service proto
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config proto(Descriptors.FileDescriptor proto);
+        Rules proto(Descriptors.FileDescriptor proto);
 
         /**
          * Register the {@link MarshallerSupplier} for the service.
          *
          * @param marshallerSupplier the {@link MarshallerSupplier} for the service
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config marshallerSupplier(MarshallerSupplier marshallerSupplier);
+        Rules marshallerSupplier(MarshallerSupplier marshallerSupplier);
 
         /**
          * Register one or more {@link io.grpc.ServerInterceptor interceptors} for the service.
          *
          * @param interceptors the interceptor(s) to register
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config intercept(ServerInterceptor... interceptors);
+        Rules intercept(ServerInterceptor... interceptors);
 
         /**
          * Register one or more {@link io.grpc.ServerInterceptor interceptors} for a named method of the service.
@@ -209,11 +209,11 @@ public class ServiceDescriptor {
          * @param methodName   the name of the method to intercept
          * @param interceptors the interceptor(s) to register
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          *
          * @throws IllegalArgumentException if no method exists for the specified name
          */
-        Config intercept(String methodName, ServerInterceptor... interceptors);
+        Rules intercept(String methodName, ServerInterceptor... interceptors);
 
         /**
          * Add value to the {@link io.grpc.Context} for the service.
@@ -221,9 +221,9 @@ public class ServiceDescriptor {
          * @param key   the key for the context value
          * @param value the value to add
          * @param <V>   the type of the value
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <V> Config addContextValue(Context.Key<V> key, V value);
+        <V> Rules addContextValue(Context.Key<V> key, V value);
 
         /**
          * Register unary method for the service.
@@ -232,9 +232,9 @@ public class ServiceDescriptor {
          * @param method the unary method to register
          * @param <ReqT> the method request type
          * @param <ResT> the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config unary(String name, ServerCalls.UnaryMethod<ReqT, ResT> method);
+        <ReqT, ResT> Rules unary(String name, ServerCalls.UnaryMethod<ReqT, ResT> method);
 
         /**
          * Register unary method for the service.
@@ -244,11 +244,11 @@ public class ServiceDescriptor {
          * @param configurer the method configurer
          * @param <ReqT>     the method request type
          * @param <ResT>     the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config unary(String name,
-                                  ServerCalls.UnaryMethod<ReqT, ResT> method,
-                                  Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer);
+        <ReqT, ResT> Rules unary(String name,
+                                 ServerCalls.UnaryMethod<ReqT, ResT> method,
+                                 Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer);
 
         /**
          * Register server streaming method for the service.
@@ -257,9 +257,9 @@ public class ServiceDescriptor {
          * @param method the server streaming method to register
          * @param <ReqT> the method request type
          * @param <ResT> the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config serverStreaming(String name, ServerCalls.ServerStreamingMethod<ReqT, ResT> method);
+        <ReqT, ResT> Rules serverStreaming(String name, ServerCalls.ServerStreamingMethod<ReqT, ResT> method);
 
         /**
          * Register server streaming method for the service.
@@ -269,11 +269,11 @@ public class ServiceDescriptor {
          * @param configurer the method configurer
          * @param <ReqT>     the method request type
          * @param <ResT>     the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config serverStreaming(String name,
-                                            ServerCalls.ServerStreamingMethod<ReqT, ResT> method,
-                                            Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer);
+        <ReqT, ResT> Rules serverStreaming(String name,
+                                           ServerCalls.ServerStreamingMethod<ReqT, ResT> method,
+                                           Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer);
 
         /**
          * Register client streaming method for the service.
@@ -282,9 +282,9 @@ public class ServiceDescriptor {
          * @param method the client streaming method to register
          * @param <ReqT> the method request type
          * @param <ResT> the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config clientStreaming(String name, ServerCalls.ClientStreamingMethod<ReqT, ResT> method);
+        <ReqT, ResT> Rules clientStreaming(String name, ServerCalls.ClientStreamingMethod<ReqT, ResT> method);
 
         /**
          * Register client streaming method for the service.
@@ -294,11 +294,11 @@ public class ServiceDescriptor {
          * @param configurer the method configurer
          * @param <ReqT>     the method request type
          * @param <ResT>     the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config clientStreaming(String name,
-                                            ServerCalls.ClientStreamingMethod<ReqT, ResT> method,
-                                            Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer);
+        <ReqT, ResT> Rules clientStreaming(String name,
+                                           ServerCalls.ClientStreamingMethod<ReqT, ResT> method,
+                                           Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer);
 
         /**
          * Register bi-directional streaming method for the service.
@@ -307,9 +307,9 @@ public class ServiceDescriptor {
          * @param method the bi-directional streaming method to register
          * @param <ReqT> the method request type
          * @param <ResT> the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config bidirectional(String name, ServerCalls.BidiStreamingMethod<ReqT, ResT> method);
+        <ReqT, ResT> Rules bidirectional(String name, ServerCalls.BidiStreamingMethod<ReqT, ResT> method);
 
         /**
          * Register bi-directional streaming method for the service.
@@ -319,54 +319,54 @@ public class ServiceDescriptor {
          * @param configurer the method configurer
          * @param <ReqT>     the method request type
          * @param <ResT>     the method response type
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        <ReqT, ResT> Config bidirectional(String name,
-                                          ServerCalls.BidiStreamingMethod<ReqT, ResT> method,
-                                          Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer);
+        <ReqT, ResT> Rules bidirectional(String name,
+                                         ServerCalls.BidiStreamingMethod<ReqT, ResT> method,
+                                         Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer);
 
         /**
          * Register the service {@link HealthCheck}.
          *
          * @param healthCheck the service {@link HealthCheck}
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config healthCheck(HealthCheck healthCheck);
+        Rules healthCheck(HealthCheck healthCheck);
 
         /**
          * Collect metrics for this service using {@link org.eclipse.microprofile.metrics.Counter}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config counted();
+        Rules counted();
 
         /**
          * Collect metrics for this service using {@link org.eclipse.microprofile.metrics.Meter}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config metered();
+        Rules metered();
 
         /**
          * Collect metrics for this service using {@link org.eclipse.microprofile.metrics.Histogram}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config histogram();
+        Rules histogram();
 
         /**
          * Collect metrics for this service using {@link org.eclipse.microprofile.metrics.Timer}.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config timed();
+        Rules timed();
 
         /**
          * Explicitly disable metrics collection for this service.
          *
-         * @return this {@link Config} instance for fluent call chaining
+         * @return this {@link io.helidon.grpc.server.ServiceDescriptor.Rules} instance for fluent call chaining
          */
-        Config disableMetrics();
+        Rules disableMetrics();
     }
 
     // ---- inner class: Aware ----------------------------------------------
@@ -389,7 +389,7 @@ public class ServiceDescriptor {
     /**
      * A {@link ServiceDescriptor} builder.
      */
-    public static final class Builder implements Config, io.helidon.common.Builder<ServiceDescriptor> {
+    public static final class Builder implements Rules, io.helidon.common.Builder<ServiceDescriptor> {
         private final Class<?> serviceClass;
 
         private String name;
@@ -469,7 +469,7 @@ public class ServiceDescriptor {
         @Override
         public <ReqT, ResT> Builder unary(String name,
                                           ServerCalls.UnaryMethod<ReqT, ResT> method,
-                                          Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer) {
+                                          Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer) {
             methodBuilders.put(name, createMethodDescriptor(name,
                                                             io.grpc.MethodDescriptor.MethodType.UNARY,
                                                             ServerCalls.asyncUnaryCall(method),
@@ -485,7 +485,7 @@ public class ServiceDescriptor {
         @Override
         public <ReqT, ResT> Builder serverStreaming(String name,
                                                     ServerCalls.ServerStreamingMethod<ReqT, ResT> method,
-                                                    Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer) {
+                                                    Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer) {
             methodBuilders.put(name, createMethodDescriptor(name,
                                                             io.grpc.MethodDescriptor.MethodType.SERVER_STREAMING,
                                                             ServerCalls.asyncServerStreamingCall(method),
@@ -501,7 +501,7 @@ public class ServiceDescriptor {
         @Override
         public <ReqT, ResT> Builder clientStreaming(String name,
                                                     ServerCalls.ClientStreamingMethod<ReqT, ResT> method,
-                                                    Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer) {
+                                                    Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer) {
             methodBuilders.put(name, createMethodDescriptor(name,
                                                             io.grpc.MethodDescriptor.MethodType.CLIENT_STREAMING,
                                                             ServerCalls.asyncClientStreamingCall(method),
@@ -517,7 +517,7 @@ public class ServiceDescriptor {
         @Override
         public <ReqT, ResT> Builder bidirectional(String name,
                                                   ServerCalls.BidiStreamingMethod<ReqT, ResT> method,
-                                                  Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer) {
+                                                  Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer) {
             methodBuilders.put(name, createMethodDescriptor(name,
                                                             io.grpc.MethodDescriptor.MethodType.BIDI_STREAMING,
                                                             ServerCalls.asyncBidiStreamingCall(method),
@@ -609,7 +609,7 @@ public class ServiceDescriptor {
                 String methodName,
                 io.grpc.MethodDescriptor.MethodType methodType,
                 ServerCallHandler<ReqT, ResT> callHandler,
-                Consumer<MethodDescriptor.Config<ReqT, ResT>> configurer) {
+                Consumer<MethodDescriptor.Rules<ReqT, ResT>> configurer) {
             Class<ReqT> requestType = (Class<ReqT>) getTypeFromMethodDescriptor(methodName, true);
             Class<ResT> responseType = (Class<ResT>) getTypeFromMethodDescriptor(methodName, false);
 

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcMetricsInterceptorIT.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcMetricsInterceptorIT.java
@@ -196,7 +196,7 @@ public class GrpcMetricsInterceptorIT {
     public void shouldUseMethodOverrideToSetCounterMetric() {
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .metered()
-                .unary("barOverrideCount", this::dummyUnary, MethodDescriptor.Config::counted)
+                .unary("barOverrideCount", this::dummyUnary, MethodDescriptor.Rules::counted)
                 .build();
 
         MethodDescriptor methodDescriptor = descriptor.method("barOverrideCount");
@@ -218,7 +218,7 @@ public class GrpcMetricsInterceptorIT {
     public void shouldUseMethodOverrideToSetHistogramMetric() {
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .metered()
-                .unary("barOverrideHistogram", this::dummyUnary, MethodDescriptor.Config::histogram)
+                .unary("barOverrideHistogram", this::dummyUnary, MethodDescriptor.Rules::histogram)
                 .build();
 
         MethodDescriptor methodDescriptor = descriptor.method("barOverrideHistogram");
@@ -240,7 +240,7 @@ public class GrpcMetricsInterceptorIT {
     public void shouldUseMethodOverrideToSetMeterMetric() {
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .metered()
-                .unary("barOverrideMeter", this::dummyUnary, MethodDescriptor.Config::metered)
+                .unary("barOverrideMeter", this::dummyUnary, MethodDescriptor.Rules::metered)
                 .build();
 
         MethodDescriptor methodDescriptor = descriptor.method("barOverrideMeter");
@@ -262,7 +262,7 @@ public class GrpcMetricsInterceptorIT {
     public void shouldUseMethodOverrideToSetTimerMetric() {
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .metered()
-                .unary("barOverrideTimer", this::dummyUnary, MethodDescriptor.Config::timed)
+                .unary("barOverrideTimer", this::dummyUnary, MethodDescriptor.Rules::timed)
                 .build();
 
         MethodDescriptor methodDescriptor = descriptor.method("barOverrideTimer");
@@ -284,7 +284,7 @@ public class GrpcMetricsInterceptorIT {
     public void shouldUseMethodOverrideToDisableMetrics() {
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .metered()
-                .unary("barOverrideOff", this::dummyUnary, MethodDescriptor.Config::disableMetrics)
+                .unary("barOverrideOff", this::dummyUnary, MethodDescriptor.Rules::disableMetrics)
                 .build();
 
         MethodDescriptor methodDescriptor = descriptor.method("barOverrideOff");

--- a/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServiceTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/GrpcServiceTest.java
@@ -514,7 +514,7 @@ public class GrpcServiceTest {
     private class GrpcServiceStub
             implements GrpcService {
         @Override
-        public void update(ServiceDescriptor.Config config) {
+        public void update(ServiceDescriptor.Rules rules) {
         }
     }
 }

--- a/grpc/server/src/test/java/io/helidon/grpc/server/ServiceDescriptorTest.java
+++ b/grpc/server/src/test/java/io/helidon/grpc/server/ServiceDescriptorTest.java
@@ -202,7 +202,7 @@ public class ServiceDescriptorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAddBidirectionalMethodWithConfigurer() {
-        Consumer<MethodDescriptor.Config<String, String>> configurer = mock(Consumer.class);
+        Consumer<MethodDescriptor.Rules<String, String>> configurer = mock(Consumer.class);
 
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .bidirectional("methodOne", this::dummyBiDi, configurer)
@@ -255,7 +255,7 @@ public class ServiceDescriptorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAddClientStreamingMethodWithConfigurer() {
-        Consumer<MethodDescriptor.Config<String, String>> configurer = mock(Consumer.class);
+        Consumer<MethodDescriptor.Rules<String, String>> configurer = mock(Consumer.class);
 
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .clientStreaming("methodOne", this::dummyClientStreaming, configurer)
@@ -308,7 +308,7 @@ public class ServiceDescriptorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAddServerStreamingMethodWithConfigurer() {
-        Consumer<MethodDescriptor.Config<String, String>> configurer = mock(Consumer.class);
+        Consumer<MethodDescriptor.Rules<String, String>> configurer = mock(Consumer.class);
 
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .serverStreaming("methodOne", this::dummyServerStreaming, configurer)
@@ -361,7 +361,7 @@ public class ServiceDescriptorTest {
     @Test
     @SuppressWarnings("unchecked")
     public void shouldAddUnaryMethodWithConfigurer() {
-        Consumer<MethodDescriptor.Config<String, String>> configurer = mock(Consumer.class);
+        Consumer<MethodDescriptor.Rules<String, String>> configurer = mock(Consumer.class);
 
         ServiceDescriptor descriptor = ServiceDescriptor.builder(createMockService())
                 .unary("methodOne", this::dummyServerStreaming, configurer)

--- a/grpc/server/src/test/java/services/EchoService.java
+++ b/grpc/server/src/test/java/services/EchoService.java
@@ -29,8 +29,8 @@ public class EchoService
         implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.proto(Echo.getDescriptor())
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.proto(Echo.getDescriptor())
                 .unary("Echo", this::echo);
     }
 

--- a/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurity.java
+++ b/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurity.java
@@ -102,7 +102,7 @@ import io.opentracing.contrib.grpc.OpenTracingContextKey;
 // we need to have all fields optional and this is cleaner than checking for null
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public final class GrpcSecurity
-        implements PriorityServerInterceptor, Consumer<ServiceDescriptor.Config> {
+        implements PriorityServerInterceptor, Consumer<ServiceDescriptor.Rules> {
     private static final Logger LOGGER = Logger.getLogger(GrpcSecurity.class.getName());
 
     /**
@@ -372,23 +372,23 @@ public final class GrpcSecurity
     }
 
     /**
-     * If the {@link #config} field is set then modify the {@link ServiceDescriptor.Config}
+     * If the {@link #config} field is set then modify the {@link ServiceDescriptor.Rules}
      * with any applicable security configuration.
      *
-     * @param serviceConfig  the {@link ServiceDescriptor.Config} to modify
+     * @param rules  the {@link ServiceDescriptor.Rules} to modify
      */
     @Override
-    public void accept(ServiceDescriptor.Config serviceConfig) {
-        config.ifPresent(grpcConfig -> modifyServiceDescriptorConfig(serviceConfig, grpcConfig));
+    public void accept(ServiceDescriptor.Rules rules) {
+        config.ifPresent(grpcConfig -> modifyServiceDescriptorConfig(rules, grpcConfig));
     }
 
-    private void modifyServiceDescriptorConfig(ServiceDescriptor.Config serviceConfig, Config grpcConfig) {
-        String serviceName = serviceConfig.name();
+    private void modifyServiceDescriptorConfig(ServiceDescriptor.Rules rules, Config grpcConfig) {
+        String serviceName = rules.name();
 
         grpcConfig.get("services")
                 .asNodeList()
                 .map(list -> findServiceConfig(serviceName, list))
-                .ifPresent(cfg -> configureServiceSecurity(serviceConfig, cfg));
+                .ifPresent(cfg -> configureServiceSecurity(rules, cfg));
     }
 
     private Config findServiceConfig(String serviceName, List<Config> list) {
@@ -398,7 +398,7 @@ public final class GrpcSecurity
                 .orElse(null);
     }
 
-    private void configureServiceSecurity(ServiceDescriptor.Config serviceConfig, Config grpcServiceConfig) {
+    private void configureServiceSecurity(ServiceDescriptor.Rules rules, Config grpcServiceConfig) {
         if (grpcServiceConfig.exists()) {
             GrpcSecurityHandler defaults;
 
@@ -418,11 +418,11 @@ public final class GrpcSecurity
                                                          .key() + " must contain name key with a method name to "
                                                          + "register to gRPC server security"));
 
-                        serviceConfig.intercept(name, GrpcSecurityHandler.create(methodConfig, defaults));
+                        rules.intercept(name, GrpcSecurityHandler.create(methodConfig, defaults));
                     }
                 });
             } else {
-                serviceConfig.intercept(defaults);
+                rules.intercept(defaults);
             }
         }
     }

--- a/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurityHandler.java
+++ b/security/integration/grpc/src/main/java/io/helidon/security/integration/grpc/GrpcSecurityHandler.java
@@ -76,7 +76,7 @@ import static io.helidon.security.AuditEvent.AuditParam.plain;
 // we need to have all fields optional and this is cleaner than checking for null
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class GrpcSecurityHandler
-        implements PriorityServerInterceptor, Consumer<ServiceDescriptor.Config> {
+        implements PriorityServerInterceptor, Consumer<ServiceDescriptor.Rules> {
     private static final Logger LOGGER = Logger.getLogger(GrpcSecurityHandler.class.getName());
     private static final String KEY_ROLES_ALLOWED = "roles-allowed";
     private static final String KEY_AUTHENTICATOR = "authenticator";
@@ -147,7 +147,8 @@ public class GrpcSecurityHandler
      * <pre>
      * {
      *   #
-     *   # these are used by {@link GrpcSecurity} when loaded from config, to register with {@link io.helidon.webserver.WebServer}
+     *   # these are used by {@link GrpcSecurity} when loaded from config, to register
+     *   # with the {@link io.helidon.grpc.server.GrpcServer}
      *   #
      *   path = "/noRoles"
      *   methods = ["get"]
@@ -293,13 +294,13 @@ public class GrpcSecurityHandler
     }
 
     /**
-     * Modifies a {@link ServiceDescriptor.Config} to add this {@link GrpcSecurityHandler}.
+     * Modifies a {@link io.helidon.grpc.server.ServiceDescriptor.Rules} to add this {@link GrpcSecurityHandler}.
      *
-     * @param config  the {@link ServiceDescriptor.Config} to modify
+     * @param rules  the {@link io.helidon.grpc.server.ServiceDescriptor.Rules} to modify
      */
     @Override
-    public void accept(ServiceDescriptor.Config config) {
-        config.addContextValue(GrpcSecurity.GRPC_SECURITY_HANDLER, this);
+    public void accept(ServiceDescriptor.Rules rules) {
+        rules.addContextValue(GrpcSecurity.GRPC_SECURITY_HANDLER, this);
     }
 
     @Override

--- a/security/integration/grpc/src/test/java/services/EchoService.java
+++ b/security/integration/grpc/src/test/java/services/EchoService.java
@@ -29,8 +29,8 @@ public class EchoService
         implements GrpcService {
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.proto(Echo.getDescriptor())
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.proto(Echo.getDescriptor())
                 .unary("Echo", this::echo);
     }
 

--- a/security/integration/grpc/src/test/java/services/SecuredOutboundEchoService.java
+++ b/security/integration/grpc/src/test/java/services/SecuredOutboundEchoService.java
@@ -47,8 +47,8 @@ public class SecuredOutboundEchoService
     }
 
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.name("EchoService")
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.name("EchoService")
                 .proto(Echo.getDescriptor())
                 .unary("Echo", this::echo);
     }

--- a/security/integration/grpc/src/test/java/services/StringService.java
+++ b/security/integration/grpc/src/test/java/services/StringService.java
@@ -31,8 +31,8 @@ import io.grpc.stub.StreamObserver;
 public class StringService
         implements GrpcService {
     @Override
-    public void update(ServiceDescriptor.Config config) {
-        config.proto(Strings.getDescriptor())
+    public void update(ServiceDescriptor.Rules rules) {
+        rules.proto(Strings.getDescriptor())
                 .unary("Upper", this::upper)
                 .unary("Lower", this::lower)
                 .serverStreaming("Split", this::split)


### PR DESCRIPTION
Rename gRPC server `ServiceDescriptor.Config` interface to `ServiceDe…scriptor.Rules` and `MethodDescriptor.Config` to `MethodDescriptor.Rules` based on pull-request feedback. Also changed corresponding variable names, parameter names and documentation usage. (issue #72)